### PR TITLE
Update so pixel watch bedtime sync works

### DIFF
--- a/wear/src/main/java/de/rhaeus/dndsync/DNDSyncAccessService.java
+++ b/wear/src/main/java/de/rhaeus/dndsync/DNDSyncAccessService.java
@@ -80,7 +80,7 @@ public class DNDSyncAccessService extends AccessibilityService {
         final int top = (int)(height * .25);
         final int mid = (int)(height * .5);
         final int bottom = (int)(height * .75);
-        final int midX = displayMetrics.widthPixels / 2;
+        final int midX = displayMetrics.widthPixels / 3;
 
         path.moveTo(midX, 0);
         path.lineTo(midX, mid);


### PR DESCRIPTION
I *think* all that's needed to make the pixel watch bedtime sync work is to edit the midx value (which is currently the "middle" of the row for samsung watches) to instead be divided by 3. That way we get the first (left) 3rd of the screen as the click target for the midx value. And that's where the pixel watch has the bedtime mode button. I was too lazy to install the android sdk and build/debug this myself - hoping the dev is willing to give it a shot for us :).